### PR TITLE
fix(snap): Update snap versioning logic

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,9 +1,6 @@
 name: edgex-device-camera
 base: core18
-version: "0.0.0"
-version-script: |
-  VERSION=$(shell cat ./VERSION 2>/dev/null || echo 0.0.0)
-  echo $VERSION-$(date +%Y%m%d)+$(git rev-parse --short HEAD)
+adopt-info: version
 license: Apache-2.0
 summary: Control/communicate with ONVIF-compliant cameras using Camera Device Service
 title: EdgeX Camera Device Service
@@ -38,6 +35,17 @@ apps:
     plugs: [network, network-bind]
 
 parts:
+  version:
+    plugin: nil
+    source: snap/local
+    override-pull: |
+      cd $SNAPCRAFT_PROJECT_DIR
+      if [ -f VERSION ]; then
+        PROJECT_VERSION=$(cat VERSION)
+      else
+        PROJECT_VERSION="0.0.0"
+      fi
+      snapcraftctl set-version ${PROJECT_VERSION}
   go:
     plugin: nil
     source: snap/local


### PR DESCRIPTION
This fix contains three minor changes to the way version numbers are generated when building the snap:
1) Git tag and datestamp have been removed from the version number. The version number is therefore now just "1.1.3-dev.5", as opposed to "1.1.3-dev.4-20201021+856f4f8"
2) Instead of using "version-script" (which has been deprecated) we now use "snapcraftctl set-version"
3) Instead of using "shell cat", we now use "cat" as otherwise the VERSION file may not be found, depending on the build setup.

Signed-off-by: Siggi Skulason <siggi.skulason@canonical.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://wiki.edgexfoundry.org/display/FA/Contributor%27s+Guide
- [N/A] Tests for the changes have been added (for bug fixes / features)
- [N/A] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->

The snap version is in the format "1.1.3-dev.4-20201021+856f4f8"
Issue Number:


## What is the new behavior?

The snap version will be in the format "1.1.3-dev.4"

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## Are there any new imports or modules? If so, what are they used for and why?


## Are there any specific instructions or things that should be known prior to reviewing?

## Other information