### PR TITLE
fix: Set mediaType on all Binary resources

### DIFF
--- a/cmd/res/camera-bosch.yaml
+++ b/cmd/res/camera-bosch.yaml
@@ -81,7 +81,7 @@ deviceResources:
     description: "snapshot from first ONVIF MediaProfile"
     properties:
       value:
-        { type: "Binary", readWrite: "R" }
+        { type: "Binary", readWrite: "R", mediaType : "image/jpeg" }
       units:
         { type: "Binary", readWrite: "R", defaultValue: "ONVIFSnapshot" }
   - name: "motion_detected"

--- a/cmd/res/camera.yaml
+++ b/cmd/res/camera.yaml
@@ -80,7 +80,7 @@ deviceResources:
     description: "snapshot from first ONVIF MediaProfile"
     properties:
       value:
-        { type: "Binary", readWrite: "R" }
+        { type: "Binary", readWrite: "R", mediaType : "image/jpeg" }
       units:
         { type: "Binary", readWrite: "R", defaultValue: "ONVIFSnapshot" }
   - name: "OnvifUser"


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/device-camera-go/blob/master/.github/CONTRIBUTING.md

## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->
MediaType not set on Binary resources

## Issue Number:  #84


## What is the new behavior?
MediaType now set on all Binary resources


## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [x] No

## Specific Instructions
<!-- Are there any specific instructions or things that should be known prior to reviewing? -->

## Other information
