### PR TITLE
fix(snap): run 'go mod tidy'

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -57,6 +57,7 @@ parts:
       - go/1.16/stable
     override-build: |
       cd $SNAPCRAFT_PART_SRC
+      go mod tidy
       make build
 
       install -DT "./cmd/device-camera-go" "$SNAPCRAFT_PART_INSTALL/bin/device-camera-go"


### PR DESCRIPTION
This commit modifies the snap build to run 'go mod tidy' before 'make build' due to a
known issue with go 1.16.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [NA] Tests for the changes have been added (for bug fixes / features)
- [NA] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/device-camera-go/blob/master/.github/CONTRIBUTING.md

## What is the current behavior?
The snap build fails due to the go 1.16 update.

## Issue Number:


## What is the new behavior?
See commit message.


## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [x] No

## Specific Instructions
<!-- Are there any specific instructions or things that should be known prior to reviewing? -->

## Other information
