### PR TITLE
fix(snap): remove '-go' suffix from service name and update epoch

### DIFF
--- a/snap/README.md
+++ b/snap/README.md
@@ -30,5 +30,5 @@ The service can then be started as follows. The "--enable" option
 ensures that as well as starting the service now, it will be automatically started on boot:
 
 ```bash
-$ sudo snap start --enable edgex-device-camera.device-camera-go
+$ sudo snap start --enable edgex-device-camera.device-camera
 ```

--- a/snap/hooks/install
+++ b/snap/hooks/install
@@ -9,26 +9,26 @@ SNAP_CURRENT=${SNAP/%$SNAP_REVISION/current}
 # install all the config files from $SNAP/config/SERVICE/res/configuration.toml 
 # into $SNAP_DATA/config
 mkdir -p "$SNAP_DATA/config"
-if [ ! -f "$SNAP_DATA/config/device-camera-go/res/configuration.toml" ]; then
-    mkdir -p "$SNAP_DATA/config/device-camera-go/res"
-    cp "$SNAP/config/device-camera-go/res/configuration.toml" "$SNAP_DATA/config/device-camera-go/res/configuration.toml"
+if [ ! -f "$SNAP_DATA/config/device-camera/res/configuration.toml" ]; then
+    mkdir -p "$SNAP_DATA/config/device-camera/res"
+    cp "$SNAP/config/device-camera/res/configuration.toml" "$SNAP_DATA/config/device-camera/res/configuration.toml"
     # do replacement of the $SNAP, $SNAP_DATA, $SNAP_COMMON environment variables in the config files
     sed -i -e "s@\$SNAP_COMMON@$SNAP_COMMON@g" \
         -e "s@\$SNAP_DATA@$SNAP_DATA_CURRENT@g" \
         -e "s@\$SNAP@$SNAP_CURRENT@g" \
-        "$SNAP_DATA/config/device-camera-go/res/configuration.toml"
+        "$SNAP_DATA/config/device-camera/res/configuration.toml"
 fi
 
 # also copy the device profile into $SNAP_DATA
-find "$SNAP/config/device-camera-go/res/" -type f -print | grep .yaml | \
+find "$SNAP/config/device-camera/res/" -type f -print | grep .yaml | \
     while read line; do
         fname=$(basename "$line")
-        if [ ! -f "$SNAP_DATA/config/device-camera-go/res/${fname}" ]; then
-            cp "$SNAP/config/device-camera-go/res/${fname}" \
-                "$SNAP_DATA/config/device-camera-go/res/${fname}"
+        if [ ! -f "$SNAP_DATA/config/device-camera/res/${fname}" ]; then
+            cp "$SNAP/config/device-camera/res/${fname}" \
+                "$SNAP_DATA/config/device-camera/res/${fname}"
         fi
     done
 
-# disable device-camera-go initially because it specific requires configuration 
+# disable device-camera initially because it specific requires configuration 
 # with a device profile that will be specific to each installation
-snapctl stop --disable "$SNAP_NAME.device-camera-go"
+snapctl stop --disable "$SNAP_NAME.device-camera"

--- a/snap/hooks/pre-refresh
+++ b/snap/hooks/pre-refresh
@@ -3,4 +3,4 @@
 # save this revision for when we run again in the post-refresh
 snapctl set lastrev="$SNAP_REVISION"
 
-snapctl set release="geneva"
+snapctl set release="ireland"

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -8,8 +8,8 @@ description: |
   The EdgeX Camera Device Service is developed to control/communicate ONVIF-compliant
   cameras accessible via http in an EdgeX deployment.
   Initially the daemon in the snap is disabled - a device profile must be
-  provisioned externally with core-metadata or provided to device-camera-go inside
-  "$SNAP_DATA/config/device-camera-go/res" before starting.
+  provisioned externally with core-metadata or provided to device-camera inside
+  "$SNAP_DATA/config/device-camera/res" before starting.
 
 # TODO: add armhf when the project supports this
 architectures:
@@ -23,16 +23,16 @@ confinement: strict
 epoch: 3
 
 apps:
-  device-camera-go:
+  device-camera:
     adapter: none
-    command: bin/device-camera-go $CONFIG_PRO_ARG $CONF_ARG $REGISTRY_ARG
+    command: bin/device-camera $CONFIG_PRO_ARG $CONF_ARG $REGISTRY_ARG
     command-chain:
       - bin/startup-env-var.sh
     environment:
       CONFIG_PRO_ARG: "--cp=consul://localhost:8500"
-      CONF_ARG: "--confdir=$SNAP_DATA/config/device-camera-go/res"
+      CONF_ARG: "--confdir=$SNAP_DATA/config/device-camera/res"
       REGISTRY_ARG: "--registry"
-      DEVICE_PROFILESDIR: "$SNAP_DATA/config/device-camera-go/res"
+      DEVICE_PROFILESDIR: "$SNAP_DATA/config/device-camera/res"
     daemon: simple
     plugs: [network, network-bind]
 
@@ -49,7 +49,7 @@ parts:
       fi
       snapcraftctl set-version ${PROJECT_VERSION}
 
-  device-camera-go:
+  device-camera:
     source: .
     plugin: make
     build-packages: [git]
@@ -60,25 +60,25 @@ parts:
       go mod tidy
       make build
 
-      install -DT "./cmd/device-camera-go" "$SNAPCRAFT_PART_INSTALL/bin/device-camera-go"
+      install -DT "./cmd/device-camera" "$SNAPCRAFT_PART_INSTALL/bin/device-camera"
 
-      install -d "$SNAPCRAFT_PART_INSTALL/config/device-camera-go/res/"
+      install -d "$SNAPCRAFT_PART_INSTALL/config/device-camera/res/"
 
       cat "./cmd/res/configuration.toml" | \
-        sed -e s:\"./device-camera-go.log\":\'\$SNAP_COMMON/device-camera-go.log\': \
-          -e s:'ProfilesDir = \"./res\"':'ProfilesDir = \"\$SNAP_DATA/config/device-camera-go/res\"': > \
-        "$SNAPCRAFT_PART_INSTALL/config/device-camera-go/res/configuration.toml"
+        sed -e s:\"./device-camera.log\":\'\$SNAP_COMMON/device-camera.log\': \
+          -e s:'ProfilesDir = \"./res\"':'ProfilesDir = \"\$SNAP_DATA/config/device-camera/res\"': > \
+        "$SNAPCRAFT_PART_INSTALL/config/device-camera/res/configuration.toml"
 
       for fpath in ./cmd/res/*.yaml; do
           fname=$(basename "$fpath")
           install -DT "./cmd/res/${fname}" \
-            "$SNAPCRAFT_PART_INSTALL/config/device-camera-go/res/${fname}"
+            "$SNAPCRAFT_PART_INSTALL/config/device-camera/res/${fname}"
       done
       
       install -DT "./Attribution.txt" \
-         "$SNAPCRAFT_PART_INSTALL/usr/share/doc/device-camera-go/Attribution.txt"
+         "$SNAPCRAFT_PART_INSTALL/usr/share/doc/device-camera/Attribution.txt"
       install -DT "./LICENSE" \
-         "$SNAPCRAFT_PART_INSTALL/usr/share/doc/device-camera-go/LICENSE"
+         "$SNAPCRAFT_PART_INSTALL/usr/share/doc/device-camera/LICENSE"
 
   config-common:
     plugin: dump

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -19,8 +19,8 @@ architectures:
 grade: stable
 confinement: strict
 
-# delhi: 0, edinburgh: 1, fuji: 2, geneva: 3
-epoch: 3
+# delhi: 0, edinburgh: 1, fuji: 2, geneva/hanoi: 3, ireland: 4
+epoch: 4
 
 apps:
   device-camera:


### PR DESCRIPTION


## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/device-camera-go/blob/master/.github/CONTRIBUTING.md

## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->

The snap currently doesn't build and install correctly, as it still expects the application to install to be
`./cmd/device-camera-go` and it's been renamed in the Makefile to `./cmd/device-camera`

## Issue Number:


## What is the new behavior?

- The service name is now device-camera, not device-camera-go. Starting the device is therefore now done with
 `sudo snap start edgex-device-camera.device-camera`

- The snap path has also changed accordingly
from `/var/snap/edgex-device-camera/current/config/device-camera-go/` to `/var/snap/edgex-device-camera/current/config/device-camera/`
- The epoch value has been updated and version name set to "Ireland"

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [ ] No

BREAKING CHANGE: The epoch has been updated for Ireland.
BREAKING CHANGE: The snap service name and path has changed to device-camera

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [ ] No

## Specific Instructions
<!-- Are there any specific instructions or things that should be known prior to reviewing? -->

## Other information
