### PR TITLE
feat(security): Get Camera creds from SecretProvider

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ ARG ALPINE_PKG_EXTRA=""
 LABEL Name=edgex-device-camera-go
 
 LABEL license='SPDX-License-Identifier: Apache-2.0' \
-  copyright='Copyright (c) 2018-2020: Intel'
+  copyright='Copyright (c) 2018-2021: Intel Corp.'
 
 RUN sed -e 's/dl-cdn[.]alpinelinux.org/nl.alpinelinux.org/g' -i~ /etc/apk/repositories
 RUN apk add --no-cache ${ALPINE_PKG_BASE} ${ALPINE_PKG_EXTRA}
@@ -42,7 +42,8 @@ RUN ${MAKE}
 
 FROM alpine:3.12
 
-RUN apk add --update --no-cache zeromq
+# dumb-init needed for injected secure bootstrapping entrypoint script when run in secure mode.
+RUN apk add --update --no-cache zeromq dumb-init
 
 WORKDIR /
 COPY --from=builder /device-camera-go/cmd /

--- a/cmd/res/configuration.toml
+++ b/cmd/res/configuration.toml
@@ -6,8 +6,17 @@ LogLevel = 'INFO'
     [Writable.InsecureSecrets.DB]
     path = "redisdb"
       [Writable.InsecureSecrets.DB.Secrets]
+    [Writable.InsecureSecrets.Camera001]
+    path = "credentials001"
+      [Writable.InsecureSecrets.Camera001.Secrets]
       username = ""
       password = ""
+    # If having more than one camera, uncomment the following config settings
+    # [Writable.InsecureSecrets.Camera002]
+    # path = "credentials002"
+    #   [Writable.InsecureSecrets.Camera002.Secrets]
+    #   username = ""
+    #   password = ""
 
 [Service]
 HealthCheckInterval = '10s'
@@ -18,6 +27,19 @@ StartupMsg = 'Camera device service started'
 # MaxRequestSize limit the request body size in byte of put command
 MaxRequestSize = 0 # value 0 unlimit the request size.
 RequestTimeOut = '5s'
+
+# Only used when EDGEX_SECURITY_SECRET_STORE=true which is now required for secure consul
+[SecretStore]
+Type = 'vault'
+Host = 'localhost'
+Port = 8200
+Path = 'device-camera/'
+Protocol = 'http'
+RootCaCertPath = ''
+ServerName = ''
+TokenFile = '/tmp/edgex/secrets/device-camera/secrets-token.json'
+  [SecretStore.Authentication]
+  AuthType = 'X-Vault-Token'
 
 [Registry]
 Type = 'consul'
@@ -55,19 +77,6 @@ PublishTopicPrefix = 'edgex/events' # /<device-profile-name>/<device-name>/<sour
   ConnectTimeout = "5" # Seconds
   SkipCertVerify = "false" # Only used if Cert/Key file or Cert/Key PEMblock are specified
 
-# Only used when EDGEX_SECURITY_SECRET_STORE=true which is now required for secure consul
-[SecretStore]
-Type = 'vault'
-Host = 'localhost'
-Port = 8200
-Path = 'device-camera/'
-Protocol = 'http'
-RootCaCertPath = ''
-ServerName = ''
-TokenFile = '/tmp/edgex/secrets/device-camera/secrets-token.json'
-  [SecretStore.Authentication]
-  AuthType = 'X-Vault-Token'
-
 [Device]
 DataTransform = true
 InitCmd = ''
@@ -89,11 +98,5 @@ UseMessageBus = false
 
 # Driver configs
 [Driver]
-User = 'service'
-Password = 'Password!1'
-# Assign AuthMethod to 'digest' | 'basic' | 'none'
-# AuthMethod specifies the authentication method used when
-# requesting still images from the URL returned by the ONVIF
-# "GetSnapshotURI" command.  All ONVIF requests will be
-# carried out using digest auth.
-AuthMethod = 'basic'
+CredentialsRetryTime = '120' # Seconds
+CredentialsRetryWait = '1' # Seconds

--- a/cmd/res/devices/camera.toml
+++ b/cmd/res/devices/camera.toml
@@ -7,3 +7,26 @@ Location = 'foo'
   [DeviceList.Protocols]
     [DeviceList.Protocols.HTTP]
     Address = '192.168.2.105'
+    # Assign AuthMethod to 'digest' | 'usernamepassword' | 'none'
+    # AuthMethod specifies the authentication method used when
+    # requesting still images from the URL returned by the ONVIF
+    # "GetSnapshotURI" command.  All ONVIF requests will be
+    # carried out using digest auth.
+    AuthMethod = 'usernamepassword'
+    CredentialsPath = 'credentials001'
+# If having more than one camera, uncomment the following config settings
+#[[DeviceList]]
+#Name = 'Camera002'
+#ProfileName = 'camera-axis'
+#Description = 'My test Axis camera'
+#Location = 'bar'
+#  [DeviceList.Protocols]
+#    [DeviceList.Protocols.HTTP]
+#    Address = '192.168.2.163'
+     # Assign AuthMethod to 'digest | ''usernamepassword' | 'none'
+     # AuthMethod specifies the authentication method used when
+     # requesting still images from the URL returned by the ONVIF
+     # "GetSnapshotURI" command.  All ONVIF requests will be
+     # carried out using digest auth.
+     # AuthMethod = 'usernamepassword'
+     # CredentialsPath = 'credentials002'

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,7 @@ module github.com/edgexfoundry/device-camera-go
 
 require (
 	github.com/edgexfoundry/device-sdk-go/v2 v2.0.0-dev.71
+	github.com/edgexfoundry/go-mod-bootstrap/v2 v2.0.0-dev.58
 	github.com/edgexfoundry/go-mod-core-contracts/v2 v2.0.0-dev.94
 	github.com/faceterteam/onvif4go v0.4.0
 	github.com/pkg/errors v0.8.1

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/edgexfoundry/device-camera-go
 
 require (
 	github.com/edgexfoundry/device-sdk-go/v2 v2.0.0-dev.71
-	github.com/edgexfoundry/go-mod-bootstrap/v2 v2.0.0-dev.58
+	github.com/edgexfoundry/go-mod-bootstrap/v2 v2.0.0-dev.61
 	github.com/edgexfoundry/go-mod-core-contracts/v2 v2.0.0-dev.94
 	github.com/faceterteam/onvif4go v0.4.0
 	github.com/pkg/errors v0.8.1

--- a/internal/driver/config.go
+++ b/internal/driver/config.go
@@ -1,45 +1,90 @@
+/*******************************************************************************
+ * Copyright 2021 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ *******************************************************************************/
+
 package driver
 
 import (
 	"fmt"
+	"reflect"
+	"strconv"
 
-	sdk "github.com/edgexfoundry/device-sdk-go/v2/pkg/service"
+	"github.com/pkg/errors"
+
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/v2/models"
 )
 
 type configuration struct {
-	Camera cameraInfo
+	CredentialsRetryTime int
+	CredentialsRetryWait int
 }
 
 type cameraInfo struct {
-	User       string
-	Password   string
-	AuthMethod string
+	Address         string
+	AuthMethod      string
+	CredentialPaths string
 }
 
-const (
-	USER        = "User"
-	PASSWORD    = "Password"
-	AUTH_METHOD = "AuthMethod"
-)
-
 // loadCameraConfig loads the camera configuration
-func loadCameraConfig() (*configuration, error) {
+func loadCameraConfig(configMap map[string]string) (*configuration, error) {
 	config := new(configuration)
-	if val, ok := sdk.DriverConfigs()[USER]; ok {
-		config.Camera.User = val
-	} else {
-		return config, fmt.Errorf("driver config undefined: %s", USER)
+	err := load(configMap, config)
+	if err != nil {
+		return config, err
 	}
-	if val, ok := sdk.DriverConfigs()[PASSWORD]; ok {
-		config.Camera.Password = val
-	} else {
-		return config, fmt.Errorf("driver config undefined: %s", PASSWORD)
-	}
-	if val, ok := sdk.DriverConfigs()[AUTH_METHOD]; ok {
-		config.Camera.AuthMethod = val
-	} else {
-		return config, fmt.Errorf("driver config undefined: %s", AUTH_METHOD)
+	return config, nil
+}
+
+func CreateCameraInfo(protocols map[string]models.ProtocolProperties) (*cameraInfo, error) {
+	info := new(cameraInfo)
+	protocol, ok := protocols[HTTP_PROTOCOL]
+	if !ok {
+		return info, errors.New("unable to load config, Protocol HTTP not exist")
 	}
 
-	return config, nil
+	if err := load(protocol, info); err != nil {
+		return info, err
+	}
+
+	return info, nil
+}
+
+// load by reflect to check map key and then fetch the value
+func load(config map[string]string, des interface{}) error {
+	errorMessage := "unable to load config, '%s' not exist"
+	val := reflect.ValueOf(des).Elem()
+	for i := 0; i < val.NumField(); i++ {
+		typeField := val.Type().Field(i)
+		valueField := val.Field(i)
+
+		val, ok := config[typeField.Name]
+		if !ok {
+			return fmt.Errorf(errorMessage, typeField.Name)
+		}
+
+		switch valueField.Kind() {
+		case reflect.Int:
+			intVal, err := strconv.Atoi(val)
+			if err != nil {
+				return err
+			}
+			valueField.SetInt(int64(intVal))
+		case reflect.String:
+			valueField.SetString(val)
+		default:
+			return fmt.Errorf("none supported value type %v ,%v", valueField.Kind(), typeField.Name)
+		}
+	}
+	return nil
 }

--- a/internal/driver/constants.go
+++ b/internal/driver/constants.go
@@ -22,4 +22,7 @@ const (
 	CREDENTIALS_PATH       = "CredentialsPath"
 	CREDENTIALS_RETRY_TIME = "CredentialsRetryTime"
 	CREDENTIALS_RETRY_WAIT = "CredentialsRetryWait"
+	DIGEST_AUTH            = "digest"
+	BASIC_AUTH             = "usernamepassword"
+	NO_AUTH                = "none"
 )

--- a/internal/driver/constants.go
+++ b/internal/driver/constants.go
@@ -1,0 +1,25 @@
+/*******************************************************************************
+ * Copyright 2021 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ *******************************************************************************/
+
+package driver
+
+const (
+	HTTP_PROTOCOL          = "HTTP"
+	ADDRESS                = "Address"
+	AUTH_METHOD            = "AuthMethod"
+	CREDENTIALS_PATH       = "CredentialsPath"
+	CREDENTIALS_RETRY_TIME = "CredentialsRetryTime"
+	CREDENTIALS_RETRY_WAIT = "CredentialsRetryWait"
+)

--- a/internal/driver/driver_test.go
+++ b/internal/driver/driver_test.go
@@ -1,3 +1,18 @@
+/*******************************************************************************
+ * Copyright 2021 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ *******************************************************************************/
+
 package driver
 
 import (
@@ -40,8 +55,11 @@ func TestDriver_addrFromProtocols(t *testing.T) {
 		expectedError bool
 	}{
 		{
-			name:          "OK",
-			protocols:     map[string]models.ProtocolProperties{"HTTP": {"Address": "someaddress"}},
+			name: "OK",
+			protocols: map[string]models.ProtocolProperties{HTTP_PROTOCOL: {
+				"Address":         "someaddress",
+				"AuthMethod":      "usernamepassword",
+				"CredentialsPath": "secrets"}},
 			logger:        logger.NewMockClient(),
 			expectedValue: "someaddress",
 			expectedError: false,
@@ -55,7 +73,7 @@ func TestDriver_addrFromProtocols(t *testing.T) {
 		},
 		{
 			name:          "Missing address",
-			protocols:     map[string]models.ProtocolProperties{"HTTP": {"Secure": "True"}},
+			protocols:     map[string]models.ProtocolProperties{HTTP_PROTOCOL: {"Secure": "True"}},
 			logger:        logger.NewMockClient(),
 			expectedValue: "",
 			expectedError: true,

--- a/internal/driver/onvifclient.go
+++ b/internal/driver/onvifclient.go
@@ -37,7 +37,16 @@ func NewOnvifClient(ipAddress string, user string, password string, cameraAuth s
 	}
 
 	dev := onvif4go.NewOnvifDevice(c.ipAddress)
-	dev.Auth(user, password)
+	switch cameraAuth {
+	case BASIC_AUTH, DIGEST_AUTH:
+		dev.Auth(user, password)
+	case NO_AUTH:
+		// no op
+	default:
+		// unsupported
+		lc.Errorf("unsupported AuthMethod: %s", cameraAuth)
+		return nil
+	}
 	err := dev.Initialize()
 	if err != nil {
 		lc.Error(fmt.Sprintf("Error initializing ONVIF Client: %v", err.Error()))


### PR DESCRIPTION
- Add implementation of getting camera credentials from secret provider / secret store instead of configuration toml directly
- Remove plain text camera credentials from toml config file
- Refactor camera credentials to allow multiple different camera credentials using DeviceList instead of Driver config

Closes: #46
Signed-off-by: Jim Wang <yutsung.jim.wang@intel.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/device-camera-go/blob/master/.github/CONTRIBUTING.md

## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->
Currently the credentials of the camera are directly from plain text of TOML file and also only one universal username/password.

## Issue Number:  #46 


## What is the new behavior?
Now, the camera credentials are retrieved from secret store (via secret provider) and can be different for different cameras via using `CredentialPath` under `DeviceList` TOML section.  Just use the same creds path if they are all the same.

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x ] No

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [x ] No

## Specific Instructions
<!-- Are there any specific instructions or things that should be known prior to reviewing? -->

## Other information
