### PR TITLE
refactor: Remove the dependency of pkg/errors

### DIFF
--- a/Attribution.txt
+++ b/Attribution.txt
@@ -69,9 +69,6 @@ https://github.com/mitchellh/reflectwalk/blob/master/LICENSE
 pelletier/go-toml 1.2.0 (MIT) https://github.com/pelletier/go-toml
 https://github.com/pelletier/go-toml/blob/master/LICENSE
 
-pkg/errors 0.8.1 (BSD-2-Clause) https://github.com/pkg/errors
-https://github.com/pkg/errors/blob/master/LICENSE
-
 edgexfoundry/device-sdk-go (Apache 2.0) https://github.com/edgexfoundry/device-sdk-go/v2
 https://github.com/edgexfoundry/device-sdk-go/blob/master/LICENSE
 

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,6 @@ require (
 	github.com/edgexfoundry/go-mod-bootstrap/v2 v2.0.0-dev.61
 	github.com/edgexfoundry/go-mod-core-contracts/v2 v2.0.0-dev.94
 	github.com/faceterteam/onvif4go v0.4.0
-	github.com/pkg/errors v0.8.1
 )
 
 go 1.16

--- a/internal/driver/config.go
+++ b/internal/driver/config.go
@@ -16,11 +16,10 @@
 package driver
 
 import (
+	"errors"
 	"fmt"
 	"reflect"
 	"strconv"
-
-	"github.com/pkg/errors"
 
 	"github.com/edgexfoundry/go-mod-core-contracts/v2/v2/models"
 )


### PR DESCRIPTION
Use standard fmt and errors package instead of pkg/errors

Signed-off-by: Cloud Tsai <cloudxxx8@gmail.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/device-camera-go/blob/master/.github/CONTRIBUTING.md

## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->


## Issue Number:
fix #95 

## What is the new behavior?


## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [x] No

## Specific Instructions
<!-- Are there any specific instructions or things that should be known prior to reviewing? -->

## Other information
