### PR TITLE
fix: Fixed miss-spelled CredentialsPath in struct

### DIFF
--- a/internal/driver/config.go
+++ b/internal/driver/config.go
@@ -32,7 +32,7 @@ type configuration struct {
 type cameraInfo struct {
 	Address         string
 	AuthMethod      string
-	CredentialPaths string
+	CredentialsPath string
 }
 
 // loadCameraConfig loads the camera configuration

--- a/internal/driver/driver.go
+++ b/internal/driver/driver.go
@@ -409,7 +409,7 @@ func (d *Driver) Initialize(lc logger.LoggingClient, asyncCh chan<- *sdkModel.As
 		// need to retrieve credentials from secret provider when auth method is either basic or digest
 		if authMethod := camInfo.AuthMethod; authMethod == BASIC_AUTH || authMethod == DIGEST_AUTH {
 			// each camera can have different credentials
-			creds, err = GetCredentials(camInfo.CredentialPaths)
+			creds, err = GetCredentials(camInfo.CredentialsPath)
 			if err != nil {
 				return fmt.Errorf("failed to get credentials for camera %s: %w", dev.Name, err)
 			}
@@ -612,7 +612,7 @@ func (d *Driver) clientsFromCameraConfig(cameraConfig *cameraInfo, deviceName st
 		var creds config.Credentials
 		// need to retrieve credentials from secret provider when auth method is either basic or digest
 		if authMethod := cameraConfig.AuthMethod; authMethod == BASIC_AUTH || authMethod == DIGEST_AUTH {
-			creds, err = GetCredentials(cameraConfig.CredentialPaths)
+			creds, err = GetCredentials(cameraConfig.CredentialsPath)
 			if err != nil {
 				return nil, nil, fmt.Errorf("failed to get credentials for %s: %w", deviceName, err)
 			}
@@ -642,7 +642,7 @@ func (d *Driver) clientsFromCameraConfig(cameraConfig *cameraInfo, deviceName st
 		var creds config.Credentials
 		// need to retrieve credentials from secret provider when auth method is either basic or digest
 		if authMethod := cameraConfig.AuthMethod; authMethod == BASIC_AUTH || authMethod == DIGEST_AUTH {
-			creds, err = GetCredentials(cameraConfig.CredentialPaths)
+			creds, err = GetCredentials(cameraConfig.CredentialsPath)
 			if err != nil {
 				return nil, nil, fmt.Errorf("failed to get credentials for %s: %w", deviceName, err)
 			}


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/device-camera-go/blob/master/.github/CONTRIBUTING.md

## What is the current behavior?
`CredentialPaths` in struct should be  `CredentialsPath` 

## Issue Number: #126


## What is the new behavior?
`CredentialsPath` is now correct in the struct

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [x] No

## Specific Instructions
<!-- Are there any specific instructions or things that should be known prior to reviewing? -->

## Other information
