### PR TITLE
fix: Fix panic when camera connection fails

### DIFF
--- a/internal/driver/driver.go
+++ b/internal/driver/driver.go
@@ -397,7 +397,10 @@ func (d *Driver) Initialize(lc logger.LoggingClient, asyncCh chan<- *sdkModel.As
 
 	deviceService := sdk.RunningService()
 
+	d.lc.Info("Initializing cameras...")
 	for _, dev := range deviceService.Devices() {
+		d.lc.Infof("Initializing '%s' camera", dev.Name)
+
 		camInfo, err := CreateCameraInfo(dev.Protocols)
 
 		if err != nil {
@@ -415,7 +418,12 @@ func (d *Driver) Initialize(lc logger.LoggingClient, asyncCh chan<- *sdkModel.As
 			}
 		}
 
-		initializeOnvifClient(dev, creds.Username, creds.Password, camInfo.AuthMethod)
+		onvifClient := initializeOnvifClient(dev, creds.Username, creds.Password, camInfo.AuthMethod)
+		if onvifClient == nil {
+			d.lc.Errorf("ONVIF Client initialization for device '%s' failed: Skipping this device.", dev.Name)
+			continue
+		}
+
 		newClient(dev, creds.Username, creds.Password)
 	}
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/device-camera-go/blob/master/.github/CONTRIBUTING.md

## What is the current behavior?
Service panics when camera connection fails

## Issue Number: #128

## What is the new behavior?
Service no longer panics and logs error and skips the failed camera device.
Also added more Info log messages so see when camera devices are being initialized.

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [x] No

## Specific Instructions
<!-- Are there any specific instructions or things that should be known prior to reviewing? -->

## Other information
