### PR TITLE
fix: update PascalCase for device resource names (#138)

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -113,7 +113,7 @@ There are many ways to interact with this device service. This example shows how
     [[DeviceList.AutoEvents]]
         Interval   = "30s"
         OnChange   = false
-        SourceName = "onvif_snapshot"
+        SourceName = "OnvifSnapshot"
     ```
 
 2. Build docker image named *edgexfoundry/device-camera-go:0.0.0-dev*.

--- a/internal/driver/driver.go
+++ b/internal/driver/driver.go
@@ -95,7 +95,7 @@ func (d *Driver) HandleReadCommands(deviceName string, protocols map[string]mode
 	for i, req := range reqs {
 		switch req.DeviceResourceName {
 		// ONVIF cases
-		case "onvif_device_information":
+		case "OnvifDeviceInformation":
 			data, err = onvifClient.GetDeviceInformation()
 			if err != nil {
 				d.lc.Error(err.Error())
@@ -103,7 +103,7 @@ func (d *Driver) HandleReadCommands(deviceName string, protocols map[string]mode
 			}
 
 			cv, err = sdkModel.NewCommandValue(reqs[i].DeviceResourceName, common.ValueTypeString, string(data))
-		case "onvif_profile_information":
+		case "OnvifProfileInformation":
 			data, err = onvifClient.GetProfileInformation()
 			if err != nil {
 				d.lc.Error(err.Error())
@@ -127,7 +127,7 @@ func (d *Driver) HandleReadCommands(deviceName string, protocols map[string]mode
 			}
 
 			cv, err = sdkModel.NewCommandValue(reqs[i].DeviceResourceName, common.ValueTypeString, string(data))
-		case "onvif_dns":
+		case "OnvifDns":
 			data, err = onvifClient.GetDNS()
 			if err != nil {
 				d.lc.Error(err.Error())
@@ -135,7 +135,7 @@ func (d *Driver) HandleReadCommands(deviceName string, protocols map[string]mode
 			}
 
 			cv, err = sdkModel.NewCommandValue(reqs[i].DeviceResourceName, common.ValueTypeString, string(data))
-		case "onvif_network_interfaces":
+		case "OnvifNetworkInterfaces":
 			data, err = onvifClient.GetNetworkInterfaces()
 			if err != nil {
 				d.lc.Error(err.Error())
@@ -143,7 +143,7 @@ func (d *Driver) HandleReadCommands(deviceName string, protocols map[string]mode
 			}
 
 			cv, err = sdkModel.NewCommandValue(reqs[i].DeviceResourceName, common.ValueTypeString, string(data))
-		case "onvif_network_protocols":
+		case "OnvifNetworkProtocols":
 			data, err = onvifClient.GetNetworkProtocols()
 			if err != nil {
 				d.lc.Error(err.Error())
@@ -151,7 +151,7 @@ func (d *Driver) HandleReadCommands(deviceName string, protocols map[string]mode
 			}
 
 			cv, err = sdkModel.NewCommandValue(reqs[i].DeviceResourceName, common.ValueTypeString, string(data))
-		case "onvif_network_default_gateway":
+		case "OnvifNetworkDefaultGateway":
 			data, err = onvifClient.GetNetworkDefaultGateway()
 			if err != nil {
 				d.lc.Error(err.Error())
@@ -159,7 +159,7 @@ func (d *Driver) HandleReadCommands(deviceName string, protocols map[string]mode
 			}
 
 			cv, err = sdkModel.NewCommandValue(reqs[i].DeviceResourceName, common.ValueTypeString, string(data))
-		case "onvif_ntp":
+		case "OnvifNtp":
 			data, err = onvifClient.GetNTP()
 			if err != nil {
 				d.lc.Error(err.Error())
@@ -167,7 +167,7 @@ func (d *Driver) HandleReadCommands(deviceName string, protocols map[string]mode
 			}
 
 			cv, err = sdkModel.NewCommandValue(reqs[i].DeviceResourceName, common.ValueTypeString, string(data))
-		case "onvif_system_reboot":
+		case "OnvifSystemReboot":
 			data, err = onvifClient.Reboot()
 			if err != nil {
 				d.lc.Error(err.Error())
@@ -175,7 +175,7 @@ func (d *Driver) HandleReadCommands(deviceName string, protocols map[string]mode
 			}
 
 			cv, err = sdkModel.NewCommandValue(reqs[i].DeviceResourceName, common.ValueTypeString, string(data))
-		case "onvif_users":
+		case "OnvifUsers":
 			data, err = onvifClient.GetUsers()
 			if err != nil {
 				d.lc.Error(err.Error())
@@ -183,7 +183,7 @@ func (d *Driver) HandleReadCommands(deviceName string, protocols map[string]mode
 			}
 
 			cv, err = sdkModel.NewCommandValue(reqs[i].DeviceResourceName, common.ValueTypeString, string(data))
-		case "onvif_snapshot":
+		case "OnvifSnapshot":
 			var bytes []byte
 			bytes, err = onvifClient.GetSnapshot()
 			if err != nil {


### PR DESCRIPTION
- Aligns code with device profile changes made in PR 111

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/device-camera-go/blob/master/.github/CONTRIBUTING.md

## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->
Supplied device profiles don't work, as the resource names have been changed in the profiles (in PR #111 ) but not in the code

## Issue Number: #138 


## What is the new behavior?
Updated code to match profiles

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [x] No

## Specific Instructions
<!-- Are there any specific instructions or things that should be known prior to reviewing? -->

Changes are untested - service should be tested before approval

## Other information
