### PR TITLE
fix: use correct constants for authentication

### DIFF
--- a/internal/driver/onvifclient.go
+++ b/internal/driver/onvifclient.go
@@ -142,9 +142,9 @@ func (c *OnvifClient) GetSnapshot() ([]byte, error) {
 
 	var resp *http.Response
 
-	if c.cameraAuth == "digest" {
+	if c.cameraAuth == DIGEST_AUTH {
 		resp, err = c.digestClient.Do(req)
-	} else if c.cameraAuth == "basic" {
+	} else if c.cameraAuth == BASIC_AUTH {
 		req.SetBasicAuth(c.user, c.password)
 		httpClient := http.Client{}
 		resp, err = httpClient.Do(req)


### PR DESCRIPTION
The ONVIF client code incorrectly checks that camera authentication
is "basic" instead of "usernamepassword", so authentication failed.
Updated this to use the constants DIGEST_AUTH and BASIC_AUTH instead.

Signed-off-by: Siggi Skulason <siggi.skulason@canonical.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/device-camera-go/blob/master/.github/CONTRIBUTING.md

## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->
device-camera is currently not able to use basic (username/password) authentication to connect to an
ONVIF camera. 
 
## Issue Number:
Fix: #143 

## What is the new behavior?

device-camera now authenticates successfully and readings can be generated

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [x] No

## Specific Instructions
<!-- Are there any specific instructions or things that should be known prior to reviewing? -->

## Other information
I tested this as follows:

Connected an SV3C camera.

Created this camera.toml:

```
# Pre-defined Devices
[[DeviceList]]
Name = "Camera001"
ProfileName = "camera"
Description = "siggi"
Location = "home"
  [DeviceList.Protocols]
    [DeviceList.Protocols.HTTP]
    Address = "192.168.1.188:8080"
    # Assign AuthMethod to "digest" | "usernamepassword" | "none"
    # AuthMethod specifies the authentication method used when
    # requesting still images from the URL returned by the ONVIF
    # "GetSnapshotURI" command.  All ONVIF requests will be
    # carried out using digest auth.
    AuthMethod = "usernamepassword"
    CredentialsPath = "credentials001"
# Emit a CBOR-encoded image from this camera, as an EdgeX event, every 30 seconds
[[DeviceList.AutoEvents]]
  Interval = "30s"
  OnChange = false
  SourceName = "OnvifSnapshot"
```

Installed EdgeX and device-camera snaps, copied the camera.toml file and started the service:

```
sudo snap remove --purge edgex-device-camera
sudo snap remove --purge edgexfoundry
sudo snap install edgexfoundry --channel=2.0/stable
sudo snap install ./edgex-device-camera_2.0.1-dev.4_amd64.snap --dangerous
sudo snap connect edgexfoundry:edgex-secretstore-token edgex-device-camera:edgex-secretstore-token
sudo cp camera.toml /var/snap/edgex-device-camera/current/config/device-camera/res/devices/
sudo snap start edgex-device-camera.device-camera
```

Ran this script to update the username/password secrets:

```
#!/bin/sh

curl -w %{http_code} -X POST \
-d '{
  "apiVersion": "2",
  "path" : "credentials001",
  "secretData" : [
    {
      "key" : "username",
      "value" : "admin"
    },
	{
      "key" : "password",
      "value" : "admin"
    }
  ]
}' http://localhost:59985/api/v2/secret
```

Confirmed that I see the autoevent readings:

```
curl localhost:59880/api/v2/reading/all
```

Used a sample app-functions-sdk App I have to view the images.

```
git clone https://github.com/siggiskulason/edgex-camera-image-viewer.git
cd edgex-camera-image-viewer
./run.sh
```

