### PR TITLE
fix(snap): create VERSION file during snap build

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -60,6 +60,9 @@ parts:
     override-pull: |
       cd $SNAPCRAFT_PROJECT_DIR
       GIT_VERSION=$(git describe --tags --abbrev=0 | sed 's/v//')
+      if [ -z "$GIT_VERSION" ]; then
+        GIT_VERSION="0.0.0"
+      fi
       snapcraftctl set-version ${GIT_VERSION}
       
   hooks:
@@ -82,6 +85,15 @@ parts:
       - go/1.16/stable
     override-build: |
       cd $SNAPCRAFT_PART_SRC
+
+      # The makefile uses a VERSION file to set the Version string. 
+      # This file needs to be generated here
+      GIT_VERSION=$(git describe --tags --abbrev=0 | sed 's/v//')
+      if [ -z "$GIT_VERSION" ]; then
+        GIT_VERSION="0.0.0"
+      fi
+      echo $GIT_VERSION > ./VERSION
+
       go mod tidy
       make build
 


### PR DESCRIPTION
The makefile requires a `VERSION` file to be present when building the device service,
as it uses `-ldflags` to set the Version value based on the contents of that file.

When building a snap from a clean build, the `VERSION` file is not present.

This commit creates the `VERSION` file before `make build`, using the current git tag
or alternatively falling back to using 0.0.0.

Signed-off-by: Siggi Skulason <siggi.skulason@canonical.com>

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/device-camera-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/device-camera-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->
- Build the device service snap
- confirm that the `go build` line includes a valid version (i.e. `go build -ldflags "-X github.com/edgexfoundry/device-camera-go.Version=2.0.1" `)
- optionally start up the new device service snap and check the version endpoint (i.e. http://localhost:59985/api/v2/version
 )

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->