### PR TITLE
build(snap): upgrade base to core20

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: edgex-device-camera
-base: core18
+base: core20
 adopt-info: version
 license: Apache-2.0
 summary: Control/communicate with ONVIF-compliant cameras using Camera Device Service
@@ -43,8 +43,7 @@ apps:
       DEVICE_DEVICESDIR: "$SNAP_DATA/config/device-camera/res/devices"
       SECRETSTORE_TOKENFILE: $SNAP_DATA/device-camera/secrets-token.json
     daemon: simple
-    passthrough:
-      install-mode: disable
+    install-mode: disable
     plugs: [network, network-bind]
 
 plugs:


### PR DESCRIPTION
This PR upgrades the snap base from core18 to core20.

Also, it removes passthrough since `install-mode` is now available as `apps.<app-name>.install-mode`; see https://snapcraft.io/docs/snapcraft-yaml-reference

Signed-off-by: Farshid Tavakolizadeh <farshid.tavakolizadeh@canonical.com>

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/device-camera-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/device-camera-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->
```
$ snapcraft
...
Snapped edgex-device-camera_2.0.2-dev.1_amd64.snap
$ sudo snap install ./edgex-device-camera_2.0.2-dev.1_amd64.snap --dangerous
edgex-device-camera 2.0.2-dev.1 installed
$ sudo snap services edgex-device-camera
Service                            Startup   Current   Notes
edgex-device-camera.device-camera  disabled  inactive  -
$ sudo snap start edgex-device-camera
Started.
```

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->