### PR TITLE
build(snap): source metadata from central repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,13 @@ device-camera
 run
 
 VERSION
+
+# snap files
+*.snap
+*.assert
+prime/
+stage/
+parts/
+squashfs-root/
+coverage.out
+VERSION

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,17 +1,8 @@
 name: edgex-device-camera
 base: core20
-adopt-info: version
 license: Apache-2.0
-summary: Control/communicate with ONVIF-compliant cameras using Camera Device Service
-title: EdgeX Camera Device Service
-description: |
-  The EdgeX Camera Device Service is developed to control/communicate ONVIF-compliant
-  cameras accessible via http in an EdgeX deployment.
-  Initially the daemon in the snap is disabled - a device profile must be
-  provisioned externally with core-metadata or provided to device-camera inside
-  "$SNAP_DATA/config/device-camera/res" before starting.
+adopt-info: metadata
 
-# TODO: add armhf when the project supports this
 architectures:
   - build-on: amd64
   - build-on: arm64
@@ -75,6 +66,7 @@ parts:
       install -DT ./cmd/install/install "$SNAPCRAFT_PART_INSTALL/snap/hooks/install"
 
   device-camera:
+    after: [metadata]
     source: .
     plugin: make
     build-packages: [git, libzmq3-dev, pkg-config]
@@ -84,13 +76,8 @@ parts:
     override-build: |
       cd $SNAPCRAFT_PART_SRC
 
-      # The makefile uses a VERSION file to set the Version string. 
-      # This file needs to be generated here
-      GIT_VERSION=$(git describe --tags --abbrev=0 | sed 's/v//')
-      if [ -z "$GIT_VERSION" ]; then
-        GIT_VERSION="0.0.0"
-      fi
-      echo $GIT_VERSION > ./VERSION
+      # the version is needed for the build
+      cat ./VERSION
 
       go mod tidy
       make build
@@ -123,3 +110,27 @@ parts:
   config-common:
     plugin: dump
     source: snap/local/runtime-helpers
+
+  metadata:
+    plugin: nil
+    source: https://github.com/canonical/edgex-snap-metadata.git
+    source-branch: appstream
+    source-depth: 1
+    override-build: |
+      # install the icon at the default internal path
+      install -DT edgex-snap-icon.png \
+        $SNAPCRAFT_PART_INSTALL/meta/gui/icon.png
+      
+      # change to this project's repo to get the version
+      cd $SNAPCRAFT_PROJECT_DIR
+      if git describe ; then
+        VERSION=$(git describe --tags --abbrev=0 | sed 's/v//')
+      else
+        VERSION="0.0.0"
+      fi
+      
+      # write version to file for the build
+      echo $VERSION > ./VERSION
+      # set the version of this snap
+      snapcraftctl set-version $VERSION
+    parse-info: [edgex-device-camera.metainfo.xml]  

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -122,4 +122,4 @@ parts:
       echo $VERSION > ./VERSION
       # set the version of this snap
       snapcraftctl set-version $VERSION
-    parse-info: [edgex-device-camera.metainfo.xml]  
+    parse-info: [edgex-device-camera.metainfo.xml]

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -42,18 +42,7 @@ plugs:
     interface: content 
     target: $SNAP_DATA/config/device-camera
 
-parts:
-  version:
-    plugin: nil
-    source: snap/local
-    override-pull: |
-      cd $SNAPCRAFT_PROJECT_DIR
-      GIT_VERSION=$(git describe --tags --abbrev=0 | sed 's/v//')
-      if [ -z "$GIT_VERSION" ]; then
-        GIT_VERSION="0.0.0"
-      fi
-      snapcraftctl set-version ${GIT_VERSION}
-      
+parts:      
   hooks:
     source: snap/local/hooks
     plugin: make

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -79,7 +79,7 @@ parts:
       # the version is needed for the build
       cat ./VERSION
 
-      go mod tidy
+      go mod tidy -compat=1.17
       make build
 
       install -DT "./cmd/device-camera" "$SNAPCRAFT_PART_INSTALL/bin/device-camera"


### PR DESCRIPTION
The metadata kept in snapcraft.yaml is obsolete because it is being overridden on the store. This change will allow sourcing the central copy of metadata.

See https://github.com/canonical/edgex-snap-metadata/issues/2

Signed-off-by: Farshid Tavakolizadeh <farshid.tavakolizadeh@canonical.com>

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/device-mqtt-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/device-mqtt-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->
```
# clean and build:
$ snapcraft clean && snapcraft

# unpack the built snap:
$ unsquashfs name.snap

# verify that icon exists:
$ ls squashfs-root/meta/gui/icon.png 
squashfs-root/meta/gui/icon.png

# verify that version, summary and description are included:
$ cat squashfs-root/meta/snap.yaml
...
summary: EdgeX Device Camera
description: |-
  The EdgeX Device Camera is a device service for communicating with ONVIF-compliant cameras via EdgeX.
  It can be used to get and set camera attributes and retrieve snapshot images.

  **Snap usage instructions**

  https://github.com/edgexfoundry/device-camera-go/blob/main/snap/README.md

  **Source code and more info**

  https://github.com/edgexfoundry/device-camera-go

  **EdgeX documentation**

  https://docs.edgexfoundry.org

  **Reference platform snap**

  https://snapcraft.io/edgexfoundry
...
```

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->