### PR TITLE
feat(snap): add support for environment varariable injection

### DIFF
--- a/snap/local/hooks/cmd/configure/configure.go
+++ b/snap/local/hooks/cmd/configure/configure.go
@@ -24,6 +24,8 @@ import (
 	"strings"
 
 	hooks "github.com/canonical/edgex-snap-hooks/v2"
+	"github.com/canonical/edgex-snap-hooks/v2/log"
+	"github.com/canonical/edgex-snap-hooks/v2/options"
 	local "github.com/edgexfoundry/device-camera-go/hooks"
 )
 
@@ -47,6 +49,12 @@ func main() {
 		fmt.Println(fmt.Sprintf("edgex-device-camera:configure: initialization failure: %v", err))
 		os.Exit(1)
 
+	}
+
+	log.SetComponentName("configure")
+	if err := options.ProcessAppConfig("device-camera"); err != nil {
+		hooks.Error(fmt.Sprintf("could not process options: %v", err))
+		os.Exit(1)
 	}
 
 	cli := hooks.NewSnapCtl()

--- a/snap/local/hooks/go.mod
+++ b/snap/local/hooks/go.mod
@@ -1,5 +1,5 @@
 module github.com/edgexfoundry/device-camera-go/hooks
 
-require github.com/canonical/edgex-snap-hooks/v2 v2.0.7
+require github.com/canonical/edgex-snap-hooks/v2 v2.2.0-beta.5
 
 go 1.17

--- a/snap/local/hooks/go.sum
+++ b/snap/local/hooks/go.sum
@@ -1,5 +1,5 @@
-github.com/canonical/edgex-snap-hooks/v2 v2.0.7 h1:R3a8PfMffUYJsY8uw7Rosu/KURkB55tTuO8YwETV5zY=
-github.com/canonical/edgex-snap-hooks/v2 v2.0.7/go.mod h1:rOxrwdYL7hJDhxFH3uV+nVgLPjWOhJWgM5PRD5YG1jI=
+github.com/canonical/edgex-snap-hooks/v2 v2.2.0-beta.5 h1:EDFjmHy8CG4T8uFPqD+Per8Hgk250PvRsMgEDCXjYtE=
+github.com/canonical/edgex-snap-hooks/v2 v2.2.0-beta.5/go.mod h1:rOxrwdYL7hJDhxFH3uV+nVgLPjWOhJWgM5PRD5YG1jI=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=


### PR DESCRIPTION
For details on the new scheme for setting environment variables, please refer to https://github.com/edgexfoundry/edgex-go/pull/3986.

Signed-off-by: Farshid Tavakolizadeh <farshid.tavakolizadeh@canonical.com>

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/app-rfid-llrp-inventory/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/app-rfid-llrp-inventory/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->


1. Set up:
```
snap install edgexfoundry --edge
snap install edgex-device-camera --channel=edge/pr-200
```

2. Enable config and set a global config value:
```
$ snap set edgex-device-camera config-enabled=true
$ snap set edgex-device-camera config.service-startupmsg="testing injection"

$ snap start edgex-device-camera
Started.

$ snap logs -n=all edgex-device-camera | grep "testing"
2022-04-26T10:47:09+02:00 edgex-device-camera.device-camera[44710]: level=INFO ts=2022-04-26T08:47:09.92085086Z app=device-camera source=variables.go:352 msg="Variables override of 'Service.StartupMsg' by environment variable: SERVICE_STARTUPMSG=testing injection"
2022-04-26T10:47:10+02:00 edgex-device-camera.device-camera[44710]: level=INFO ts=2022-04-26T08:47:10.260535937Z app=device-camera source=message.go:55 msg="testing injection"
```

3. Set a app-specific value:
```
$ snap set edgex-device-camera apps.device-camera.config.service-port=11111

$ snap restart edgex-device-camera
Restarted.

$ snap logs -n=all edgex-device-camera | grep "11111"
2022-04-26T10:47:39+02:00 edgex-device-camera.device-camera[44902]: level=INFO ts=2022-04-26T08:47:39.401816616Z app=device-camera source=variables.go:352 msg="Variables override of 'Service.Port' by environment variable: SERVICE_PORT=11111"
2022-04-26T10:47:39+02:00 edgex-device-camera.device-camera[44902]: level=INFO ts=2022-04-26T08:47:39.414801789Z app=device-camera source=variables.go:352 msg="Variables override of 'Service.Port' by environment variable: SERVICE_PORT=11111"
2022-04-26T10:47:39+02:00 edgex-device-camera.device-camera[44902]: level=INFO ts=2022-04-26T08:47:39.440629755Z app=device-camera source=httpserver.go:123 msg="Web server starting (localhost:11111)"
```


## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->